### PR TITLE
Add config knob to suppress Trace log

### DIFF
--- a/FarmHouseRedone/Logger.cs
+++ b/FarmHouseRedone/Logger.cs
@@ -10,10 +10,13 @@ namespace FarmHouseRedone
     public static class Logger
     {
         public static IMonitor monitor;
+        public static bool suppressTrace;
 
         public static void Log(string log, LogLevel level = LogLevel.Trace)
         {
             if (monitor == null)
+                return;
+            if (Logger.suppressTrace && (level == LogLevel.Trace))
                 return;
             monitor.Log(log, level);
         }

--- a/FarmHouseRedone/ModEntry.cs
+++ b/FarmHouseRedone/ModEntry.cs
@@ -14,13 +14,27 @@ using Netcode;
 
 namespace FarmHouseRedone
 {
+    class ModConfig
+    {
+        public bool suppressTraceLog { get; set; } = false;
+    }
+
     public class ModEntry : Mod
     {
+        private ModConfig Config;
+
         public override void Entry(IModHelper helper)
         {
-            Logger.monitor = Monitor;
-            var harmony = HarmonyInstance.Create("mabelsyrup.farmhouse");
+            this.Config = this.Helper.ReadConfig<ModConfig>();
 
+            Logger.suppressTrace = this.Config.suppressTraceLog;
+            Logger.monitor = Monitor;
+            if (Logger.suppressTrace)
+            {
+                Logger.Log("WARNING: Trace Logging has been disabled from config.json!", LogLevel.Warn);
+            }
+
+            var harmony = HarmonyInstance.Create("mabelsyrup.farmhouse");
             FarmHouseStates.harmony = harmony;
             FarmHouseStates.spouseRooms = new Dictionary<string, int>();
             FarmHouseStates.reflector = helper.Reflection;


### PR DESCRIPTION
Probably due to the "beta" status, this mod is *very* chatty.

For example, in one in-game day, this mod emitted 14'000+ mod lines (out
of a total of 15'000 mod lines).

This makes troubleshooting other mods difficult.

The added config.json knob allows player to suppress the Trace log from
this mod.